### PR TITLE
style(terraform): Format tfvars files with terraform fmt (#50)

### DIFF
--- a/terraform/config/prod.tfvars
+++ b/terraform/config/prod.tfvars
@@ -1,4 +1,4 @@
-environment = "prod"
-aws_region = "us-east-2"
-project_name = "book-library-request-system"
+environment               = "prod"
+aws_region                = "us-east-2"
+project_name              = "book-library-request-system"
 use_separate_lambda_roles = true # Set to true for prod to enhance security by using separate roles

--- a/terraform/config/qa.tfvars
+++ b/terraform/config/qa.tfvars
@@ -1,4 +1,4 @@
-environment = "qa"
-aws_region = "us-east-2"
-project_name = "book-library-request-system"
+environment               = "qa"
+aws_region                = "us-east-2"
+project_name              = "book-library-request-system"
 use_separate_lambda_roles = false


### PR DESCRIPTION
- Run `terraform fmt -recursive` to format all Terraform files
- Fix formatting issues in config/prod.tfvars and config/qa.tfvars
- Resolve Terraform format check failure in CI pipeline
- Ensure consistent style across all Terraform configurations

This fixes the CI validation step that was failing with exit code 3 due to unformatted tfvars files.
Fix #23 